### PR TITLE
Bugfix: Set Admin Page Text for 'Prompts', 'Vorfallstypen' & 'Fragen' back to black

### DIFF
--- a/frontend/src/main.css
+++ b/frontend/src/main.css
@@ -6,3 +6,8 @@
 @tailwind components;
 @tailwind utilities;
 
+@layer base {
+  input, textarea, select {
+    color: black !important;
+  }
+}


### PR DESCRIPTION
Text was white due to changes deployed with last push. Fixed back to black